### PR TITLE
Do not count UDP messages that were not sent.

### DIFF
--- a/src/iperf_dccp.c
+++ b/src/iperf_dccp.c
@@ -203,8 +203,15 @@ iperf_dccp_send(struct iperf_stream *sp)
 
     r = Nwrite(sp->socket, sp->buffer, size, Pdccp);
 
-    if (r < 0)
-        return r;
+    if (r <= 0) {
+        --sp->packet_count;     /* Don't count messages that no data was sent from them.
+                                 * Allows "resending" a massage with the same numbering */
+        if (r < 0) {
+            if (sp->test->debug)
+                printf("DCCP send failed. errno=%s\n", strerror(errno));
+            return r;
+        }
+    }
 
     sp->result->bytes_sent += r;
     sp->result->bytes_sent_this_interval += r;

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -250,8 +250,15 @@ iperf_udp_send(struct iperf_stream *sp)
 
     r = Nwrite(sp->socket, sp->buffer, size, Pudp);
 
-    if (r < 0)
-	return r;
+    if (r <= 0) {
+        --sp->packet_count;     /* Don't count messages that no data was sent from them.
+                                 * Allows "resending" a massage with the same numbering */
+        if (r < 0) {
+            if (sp->test->debug)
+                printf("UDP send failed. errno=%s\n", strerror(errno));
+            return r;
+        }
+    }
 
     sp->result->bytes_sent += r;
     sp->result->bytes_sent_this_interval += r;


### PR DESCRIPTION
* Version of iperf3 : android-10.0.0_r40-mpdccp

* Issues fixed (if any):   Do not count UDP messages that were not sent
    form   https://github.com/esnet/iperf/commit/21c315df798ca0ee78de447e0202c6bd63dfe2e3


